### PR TITLE
Fix/align with spec on four directional props

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ It is a function with accepts two arguments: a CSS-in-JS object, and a string in
 
 It will convert, for instance, `paddingStart` to either `paddingLeft` or `paddingRight`, as well as all other properties where it makes sense to do so, depending on the provided `flowDirection`
 
+#### Not a polyfill
+
+It is important to note that this package is not a true polyfill for the proposal, as all start and end properties (and so on) are converted to left or right values (etc.), and will not automatically flip when the  flow direction of the element, inherited or otherwise is changes in by the html `dir` attribute or the 
+`direction` css property.
+
 ## Installation
 
 This module is distributed via [npm][npm] which is bundled with 
@@ -181,6 +186,9 @@ In properties that _do not accept the `logical` keword_ , values containing the 
 ## Caveats
 
 Same as `rtl-css-js`:
+
+This library falls short of a polyfill, and does not accommodate for dynamic changes in the flow direction. 
+[See here](#not-a-polyfill)
 
 ### `background`
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ It will convert, for instance, `paddingStart` to either `paddingLeft` or `paddin
 It is important to note that this package is not a true polyfill for the proposal, as all start and end properties (and so on) are converted to left or right values (etc.), and will not automatically flip when the  flow direction of the element, inherited or otherwise is changes in by the html `dir` attribute or the 
 `direction` css property.
 
+#### Four directional shorthand properties
+
+The proposal alters the way values for four-directional shorthand properties (`padding`, `margin`, etc.) 
+are written when using the `logical` keyword.
+
+The values of four-directional shorthand properties, _without_ the `logical` keyword are written 
+ clock-wise: `top`, `right`, `bottom` and `left`. While in `ltr` mode, that would translate to 
+ `block-start`, `inline-end`, `block-end` and `inline-start`. However, under the new spec, when the 
+ `logical` keyword is used, values order is interpreted as `block-start`, `inline-start`, `block-end` 
+ and `inline-end`.
+
+ Earlier versions of this library got this wrong, and it was corrected in version `2.0.0`
+
 ## Installation
 
 This module is distributed via [npm][npm] which is bundled with 
@@ -130,10 +143,10 @@ When the `logical` keyword is present in the value, the values that follow are a
 ```js
 bidiCSSJS({
   margin: 'logical 0 10px 0 20px'
-}, 'rtl'); // => { margin: '0 20px 0 10px' }
+}, 'rtl'); // => { margin: '0 10px 0 20px' }
 bidiCSSJS({
   margin: 'logical 0 10px 0 20px'
-}, 'ltr'); // => { margin: '0 10px 0 20px' }
+}, 'ltr'); // => { margin: '0 20px 0 10px' }
 ```
 
 
@@ -189,6 +202,9 @@ Same as `rtl-css-js`:
 
 This library falls short of a polyfill, and does not accommodate for dynamic changes in the flow direction. 
 [See here](#not-a-polyfill)
+
+While not actually a real caveat, it is worth noting that the proposal changes the way four-directional 
+shorthand properties are evaluated. [see here](#four-directional-shorthand-properties)
 
 ### `background`
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "author": "TxHawks <TofuxHawks@gmail.com> (https://githb.com/TxHawks)",
   "license": "MIT",
   "devDependencies": {
+    "commitizen": "^2.9.6",
+    "cz-conventional-changelog": "^2.0.0",
     "kcd-scripts": "^0.16.0",
     "npm-run-all": "^4.1.1",
     "rimraf": "^2.6.2"
@@ -46,5 +48,10 @@
   "bugs": {
     "url": "https://github.com/TxHawks/bidi-css-js/issues"
   },
-  "homepage": "https://github.com/TxHawks/bidi-css-js#readme"
+  "homepage": "https://github.com/TxHawks/bidi-css-js#readme",
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  }
 }

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,19 +1,21 @@
 /**
- * This tests a ton of cases for bidi-css-js and is based on the testing infrastructure created in `rtl-css-js`
- * Because there are so many test cases, there's a bit of an abstraction to make authoring/adding/maintaining tests a
- * little more ergonomic.
+ * This tests a ton of cases for bidi-css-js and is based on the testing infrastructure created in
+ * `rtl-css-js` Because there are so many test cases, there's a bit of an abstraction to make
+ * authoring/adding/maintaining tests a little more ergonomic.
  *
  * The main idea is the `tests` object. The other arrays ultimately get added to the tests object.
  *
- * One special thing about all this is the `balrog` modifier. If you add that modifier that basically tells the
- * abstraction to not even register the other tests with Jest. This makes it easier to focus on one or two tests.
+ * One special thing about all this is the `balrog` modifier. If you add that modifier that basically
+ * tells the abstraction to not even register the other tests with Jest. This makes it easier to
+ * focus on one or two tests.
  *
- * And we have a coverage threshold which should (hopefully) prevent you from accidentally adding a modifier that's
- * incorrect.
+ * And we have a coverage threshold which should (hopefully) prevent you from accidentally adding
+ * a modifier that's * incorrect.
  */
 
-/*eslint max-lines: ['error', 1500]*/
+/*eslint max-lines: ['error', 2000]*/
 
+/* prettier-ignore */
 import flowRelative from '../'
 
 // use this object for bigger tests
@@ -73,63 +75,63 @@ const shortTests = [
   ],
   [
     [{padding: 'logical 1px 2px 3px -4px'}],
-    {padding: '1px 2px 3px -4px'},
     {padding: '1px -4px 3px 2px'},
+    {padding: '1px 2px 3px -4px'},
   ],
   [
     [{padding: 'logical .25em 0ex 0pt 15px'}],
-    {padding: '.25em 0ex 0pt 15px'},
     {padding: '.25em 15px 0pt 0ex'},
+    {padding: '.25em 0ex 0pt 15px'},
   ],
   [
     [{padding: 'logical 1px 2% 3px 4.1grad'}],
-    {padding: '1px 2% 3px 4.1grad'},
     {padding: '1px 4.1grad 3px 2%'},
+    {padding: '1px 2% 3px 4.1grad'},
   ],
   [
     [{padding: 'logical 1px auto 3px 2px'}],
-    {padding: '1px auto 3px 2px'},
     {padding: '1px 2px 3px auto'},
+    {padding: '1px auto 3px 2px'},
   ],
   [
     [{padding: 'logical 1.1px 2.2px 3.3px 4.4px'}],
-    {padding: '1.1px 2.2px 3.3px 4.4px'},
     {padding: '1.1px 4.4px 3.3px 2.2px'},
+    {padding: '1.1px 2.2px 3.3px 4.4px'},
   ],
   [
     [{padding: 'logical 1px auto 3px inherit'}],
-    {padding: '1px auto 3px inherit'},
     {padding: '1px inherit 3px auto'},
+    {padding: '1px auto 3px inherit'},
   ],
   [
     [{padding: 'logical 1px 2px 3px 4px !important'}],
-    {padding: '1px 2px 3px 4px !important'},
     {padding: '1px 4px 3px 2px !important'},
+    {padding: '1px 2px 3px 4px !important'},
   ],
   [
     [{padding: 'logical 1px 2px 3px 4px !important'}],
-    {padding: '1px 2px 3px 4px !important'},
     {padding: '1px 4px 3px 2px !important'},
+    {padding: '1px 2px 3px 4px !important'},
   ],
   [
     [{padding: 'logical 1px 2px 3px 4px'}],
-    {padding: '1px 2px 3px 4px'},
     {padding: '1px 4px 3px 2px'},
+    {padding: '1px 2px 3px 4px'},
   ],
   [
     [{padding: 'logical 1px  2px   3px    4px'}],
-    {padding: '1px  2px   3px    4px'},
     {padding: '1px 4px 3px 2px'},
+    {padding: '1px  2px   3px    4px'},
   ],
   [
     [{padding: 'logical 1px 2px 3px 4px'}],
-    {padding: '1px 2px 3px 4px'},
     {padding: '1px 4px 3px 2px'},
+    {padding: '1px 2px 3px 4px'},
   ],
   [
     [{padding: 'logical 1px 2px 3px 4px !important', color: 'red'}],
-    {padding: '1px 2px 3px 4px !important', color: 'red'},
     {padding: '1px 4px 3px 2px !important', color: 'red'},
+    {padding: '1px 2px 3px 4px !important', color: 'red'},
   ],
   [
     [{padding: 10, direction: 'ets'}],
@@ -143,8 +145,8 @@ const shortTests = [
   ],
   [
     [{margin: 'logical 1px 2px 3px 4px'}],
-    {margin: '1px 2px 3px 4px'},
     {margin: '1px 4px 3px 2px'},
+    {margin: '1px 2px 3px 4px'},
   ],
   [[{float: 'start'}], {float: 'left'}, {float: 'right'}],
   [
@@ -321,13 +323,13 @@ const shortTests = [
   ],
   [
     [{borderColor: 'logical red green blue white'}],
-    {borderColor: 'red green blue white'},
     {borderColor: 'red white blue green'},
+    {borderColor: 'red green blue white'},
   ],
   [
     [{borderColor: 'logical red #f00 rgb(255, 0, 0) rgba(255, 0, 0, 0.5)'}],
-    {borderColor: 'red #f00 rgb(255, 0, 0) rgba(255, 0, 0, 0.5)'},
     {borderColor: 'red rgba(255, 0, 0, 0.5) rgb(255, 0, 0) #f00'},
+    {borderColor: 'red #f00 rgb(255, 0, 0) rgba(255, 0, 0, 0.5)'},
   ],
   [
     [
@@ -336,18 +338,18 @@ const shortTests = [
           'logical red #f00 hsl(0, 100%, 50%) hsla(0, 100%, 50%, 0.5)',
       },
     ],
-    {borderColor: 'red #f00 hsl(0, 100%, 50%) hsla(0, 100%, 50%, 0.5)'},
     {borderColor: 'red hsla(0, 100%, 50%, 0.5) hsl(0, 100%, 50%) #f00'},
+    {borderColor: 'red #f00 hsl(0, 100%, 50%) hsla(0, 100%, 50%, 0.5)'},
   ],
   [
     [{borderWidth: 'logical 1px 2px 3px 4px'}],
-    {borderWidth: '1px 2px 3px 4px'},
     {borderWidth: '1px 4px 3px 2px'},
+    {borderWidth: '1px 2px 3px 4px'},
   ],
   [
     [{borderStyle: 'logical none dotted dashed solid'}],
-    {borderStyle: 'none dotted dashed solid'},
     {borderStyle: 'none solid dashed dotted'},
+    {borderStyle: 'none dotted dashed solid'},
   ],
   [
     [{borderTopStartRadius: 0}],
@@ -371,43 +373,43 @@ const shortTests = [
   ],
   [
     [{borderRadius: 'logical 1px 2px'}],
-    {borderRadius: '1px 2px'},
     {borderRadius: '2px 1px'},
+    {borderRadius: '1px 2px'},
   ],
   [
     [{borderRadius: 'logical 1px 2px 3px 4px'}],
-    {borderRadius: '1px 2px 3px 4px'},
     {borderRadius: '2px 1px 4px 3px'},
+    {borderRadius: '1px 2px 3px 4px'},
   ],
   [
     [{borderRadius: 'logical 1px 2px 3px 4px'}],
-    {borderRadius: '1px 2px 3px 4px'},
     {borderRadius: '2px 1px 4px 3px'},
+    {borderRadius: '1px 2px 3px 4px'},
   ],
   [
     [{borderRadius: 'logical 15px / 0 20px'}],
-    {borderRadius: '15px / 0 20px'},
     {borderRadius: '15px / 20px 0'},
+    {borderRadius: '15px / 0 20px'},
   ],
   [
     [{borderRadius: 'logical 1px 2px 3px 4px / 5px 6px 7px 8px'}],
-    {borderRadius: '1px 2px 3px 4px / 5px 6px 7px 8px'},
     {borderRadius: '2px 1px 4px 3px / 6px 5px 8px 7px'},
+    {borderRadius: '1px 2px 3px 4px / 5px 6px 7px 8px'},
   ],
   [
     [{borderRadius: 'logical 1px 2px 3px 4px !important'}],
-    {borderRadius: '1px 2px 3px 4px !important'},
     {borderRadius: '2px 1px 4px 3px !important'},
+    {borderRadius: '1px 2px 3px 4px !important'},
   ],
   [
     [{borderRadius: 'logical 1px 2px 3px 4px'}],
-    {borderRadius: '1px 2px 3px 4px'},
     {borderRadius: '2px 1px 4px 3px'},
+    {borderRadius: '1px 2px 3px 4px'},
   ],
   [
     [{borderRadius: 'logical 1px 2px 3px calc(calc(2*2) * 3px)'}],
-    {borderRadius: '1px 2px 3px calc(calc(2*2) * 3px)'},
     {borderRadius: '2px 1px calc(calc(2*2) * 3px) 3px'},
+    {borderRadius: '1px 2px 3px calc(calc(2*2) * 3px)'},
   ],
   [
     [{background: 'logical url(/foo/bar.png) start top'}],

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -675,14 +675,34 @@ const shortTests = [
     {transform: 'translateX(-30%)'},
   ],
   [
+    [{transform: 'logical rotate(30%)'}],
+    {transform: 'rotate(30%)'},
+    {transform: 'rotate(-30%)'},
+  ],
+  [
+    [{transform: 'logical rotateY(30%)'}],
+    {transform: 'rotateY(30%)'},
+    {transform: 'rotateY(-30%)'},
+  ],
+  [
+    [{transform: 'logical rotateZ(30%)'}],
+    {transform: 'rotateZ(30%)'},
+    {transform: 'rotateZ(-30%)'},
+  ],
+  [
+    [{transform: 'logical rotateX(30%)'}],
+    {transform: 'rotateX(30%)'},
+    {transform: 'rotateX(30%)'},
+  ],
+  [
     [{transform: 'logical translateY(30px) rotate(20deg) translateX(10px)'}],
     {transform: 'translateY(30px) rotate(20deg) translateX(10px)'},
-    {transform: 'translateY(30px) rotate(20deg) translateX(-10px)'},
+    {transform: 'translateY(30px) rotate(-20deg) translateX(-10px)'},
   ],
   [
     [{transform: 'logical translateX(30px) rotate(20deg) translateY(10px)'}],
     {transform: 'translateX(30px) rotate(20deg) translateY(10px)'},
-    {transform: 'translateX(-30px) rotate(20deg) translateY(10px)'},
+    {transform: 'translateX(-30px) rotate(-20deg) translateY(10px)'},
   ],
   [
     [{transform: 'logical translate3d(30%, 20%, 10%)'}],


### PR DESCRIPTION
* Update to latest version of rtl-css-js which supports handling the `rotate`, `rotateY` and 
  `rotateZ` values of the `transform` property
* Add Commitizen as a `devDependency`
* Document the fact that this library is a static solution, not a polyfill

**BREAKING CHANGES**
Fix how four-directional shorthand properties are handled to align with the spec. 

The [CSS Logical Properties and Values proposal](https://www.w3.org/TR/css-logical-1) alters the way values of four-directional shorthand properties (`padding`, `margin`, etc.) 
are evaluated when using the `logical` keyword.

The values of these properties, _without_ the `logical` keyword are written evaluated clock-wise: `top`, `right`, `bottom` and `left`. While in `ltr` mode, that would translate to `block-start`, `inline-end`, `block-end` and `inline-start`. 

However, under the new spec, when the `logical` keyword is used, values order is interpreted as `block-start`, `inline-start`, `block-end` and `inline-end`.

This was previously handled wrong, and would change the output compared with versions of this library prior to this commit.
